### PR TITLE
Migrate to Artifact Registry

### DIFF
--- a/workflow-templates/yarn-build-dockerize.yml
+++ b/workflow-templates/yarn-build-dockerize.yml
@@ -10,7 +10,7 @@ env:
   GKE_CLUSTER: local-ch-stg
   GKE_PROJECT: local-ch-stg-6f80bb1e
   GKE_REGION: europe-west6
-  REGISTRY_HOST: eu.gcr.io/local-ch-registry-8e1b161f/nodejs
+  REGISTRY_HOST: europe-west6-docker.pkg.dev/local-ch-registry-8e1b161f/nodejs
 
 jobs:
   build-push:
@@ -58,7 +58,7 @@ jobs:
       - run: |
           # Set up docker to authenticate
           # via gcloud command-line tool.
-          gcloud auth configure-docker
+          gcloud auth configure-docker ${{ vars.ARTIFACT_REGISTRY }}
 
       # Calculate Deployment Name
       - name: Calculate Deployment Name


### PR DESCRIPTION
Changes all URLs from eu.gcr.io to europe-west6-docker.pkg.dev will also update the gcloud auth configure-docker command to use the new registry in GitHub Actions workflows if necessary.

> ⚠️ Please review the changes carefully, they have been made through a simple script. If you have separate deployment projects or custom deployment tools you might need to update them first. Also make sure to update any secrets or variables of this project that point to the old registry.
