### PR TITLE
Upgrade to actions/cache@v4

### DIFF
--- a/workflow-templates/yarn-build-dockerize.yml
+++ b/workflow-templates/yarn-build-dockerize.yml
@@ -32,7 +32,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
The actions/cache@v1 and v2 are being deprecated February 1, 2025.

> :bulb: Upgrading to the recommended versions will not break your workflows.
>
> https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

Please merge this PR yourself if you are happy with the changes. :pray:

Official [deprecation announcement](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/)
